### PR TITLE
Run Build CI Daily

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Rerun CI daily to keep up-to-date with upstream python updates
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR adds a cron trigger for the build CI, so we can keep the image up to date with minor versions in the python image. It'll run daily, and push new images. Behavior is otherwise unmodified.

I tried testing what happens when no modifications have been made to the output image by manually triggering the CI [here](https://github.com/owl-corp/python-poetry-base/actions/runs/4526828052/jobs/7972237028). Curiously, it failed with 500 server errors. At this point I don't know if they're temporary or permanent, so I'll stall this PR a few days and test again. I'm hoping this just works and the 500s are temporary, otherwise, we might have to do more work to get it to properly trigger.